### PR TITLE
Experimenting concurrent download of images

### DIFF
--- a/_data/data.js
+++ b/_data/data.js
@@ -46,7 +46,7 @@ const IMAGE_TYPES = [
   // 'image/png',
 ];
 
-const CONCURRENT_DOWNLOAD_LIMIT = 1;
+const CONCURRENT_DOWNLOAD_LIMIT = 2;
 
 const downloadQueue = [];
 let concurrentDownloads = 0;

--- a/_data/environment.js
+++ b/_data/environment.js
@@ -1,3 +1,4 @@
 module.exports = function () {
+  console.log('Environment variables ready');
   return { ...process.env };
 };


### PR DESCRIPTION
This reduces the image download time, but it's negligible in the whole build time. It's only meaningful if the number of images grows exponentially in the future.